### PR TITLE
Use smaller key size in demo server

### DIFF
--- a/oauth2-server-demo/src/Main.hs
+++ b/oauth2-server-demo/src/Main.hs
@@ -35,7 +35,7 @@ data State = State
 oauth2Conf :: IO (OAuth2Server IO)
 oauth2Conf = do
     ref <- newIORef (State M.empty M.empty $ S.singleton ("user", "password"))
-    key <- generateRSAKey' 4096 3
+    key <- generateRSAKey' 512 3
     Right crypto <- initPrivKey' key
     return Configuration
         { oauth2CheckCredentials = checkCredentials ref

--- a/tests/acceptance-tests.sh
+++ b/tests/acceptance-tests.sh
@@ -11,8 +11,6 @@ ROOT=$(git rev-parse --show-toplevel)
 SERVER=oauth2-server-demo
 $ROOT/$SERVER/dist/build/$SERVER/$SERVER > /dev/null 2>&1 &
 
-sleep 5
-
 declare -g URL="http://127.0.0.1:8000/oauth2/token"
 
 declare -g ERRORS=""


### PR DESCRIPTION
I used far to big keys in the demo server. The idea is not to test openssl but the implementation of the server.