### PR TITLE
Treat access and refresh tokens separately

### DIFF
--- a/oauth2-server/lib/Network/OAuth2/Server/CryptoTokenStore.hs
+++ b/oauth2-server/lib/Network/OAuth2/Server/CryptoTokenStore.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE RecordWildCards #-}
 module Network.OAuth2.Server.CryptoTokenStore where
 
+import Control.Lens
 import Control.Monad.IO.Class
 import qualified Data.Set as Set
 
 import Crypto.AnchorToken
 
-import Network.OAuth2.Server.Configuration
-import Network.OAuth2.Server.Types
+import Network.OAuth2.Server
 
+-- | Given a key pair, /load/ a 'TokenGrant' by decrypting a 'Token'.
 cryptoTokenStore
     :: MonadIO m
     => AnchorCryptoState Pair
@@ -18,21 +19,14 @@ cryptoTokenStore key = TokenStore
     , tokenStoreLoad = load key
     }
 
+-- | Given a key pair, /load/ a 'TokenGrant' by decrypting a 'Token'.
 load
     :: MonadIO m
-    => AnchorCryptoState a
+    => AnchorCryptoState Pair
     -> Token
     -> m (Maybe TokenGrant)
 load key (Token token) = do
     tok <- liftIO $ verifyToken key token
     case tok of
         Left _ -> return Nothing
-        Right AnchorToken{..} -> return $ Just TokenGrant
-            { grantTokenType = _tokenType
-            , grantAccessToken = Token token
-            , grantRefreshToken = Just $ Token token
-            , grantExpires = _tokenExpires
-            , grantUsername = _tokenUserName
-            , grantClientID = _tokenClientID
-            , grantScope = Scope $ Set.fromList _tokenScope
-            }
+        Right t -> return $ preview (anchorTokenTokenGrant key) t

--- a/oauth2-server/lib/Network/OAuth2/Server/Types.hs
+++ b/oauth2-server/lib/Network/OAuth2/Server/Types.hs
@@ -116,8 +116,7 @@ data AccessResponse = AccessResponse
 -- future.
 data TokenGrant = TokenGrant
     { grantTokenType    :: Text
-    , grantAccessToken  :: Token
-    , grantRefreshToken :: Maybe Token
+    , grantToken        :: Token
     , grantExpires      :: UTCTime
     , grantUsername     :: Maybe Text
     , grantClientID     :: Maybe Text
@@ -127,12 +126,13 @@ data TokenGrant = TokenGrant
 
 -- | Convert a 'TokenGrant' into an 'AccessResponse'.
 grantResponse
-    :: TokenGrant
+    :: TokenGrant -- ^ Token details.
+    -> Maybe Token  -- ^ Associated refresh token.
     -> AccessResponse
-grantResponse TokenGrant{..} = AccessResponse
+grantResponse TokenGrant{..} refresh = AccessResponse
     { tokenType     = grantTokenType
-    , accessToken   = grantAccessToken
-    , refreshToken  = grantRefreshToken
+    , accessToken   = grantToken
+    , refreshToken  = refresh
     , tokenExpires  = grantExpires
     , tokenUsername = grantUsername
     , tokenClientID = grantClientID

--- a/tests/acceptance-tests/refresh-token.sh
+++ b/tests/acceptance-tests/refresh-token.sh
@@ -39,5 +39,11 @@ OUTPUT=$(refresh "bad-token") \
 # Refresh with a valid token returns a new token.
 TOKEN=$(ropcg "user" "password" | tr "," "\n" | grep refresh | cut -d\" -f4)
 OUTPUT=$(refresh "$TOKEN") \
-        && pass "Got refresh with valid token." \
-        || fail "Could not refresh with valid token ($TOKEN)." "$OUTPUT"
+        && pass "Could refresh with valid refresh token." \
+        || fail "Could not refresh with valid refresh token ($TOKEN)." "$OUTPUT"
+
+# Refresh with an access token returns an error.
+TOKEN=$(ropcg "user" "password" | tr "," "\n" | grep access | cut -d\" -f4)
+OUTPUT=$(refresh "$TOKEN") \
+        && fail "Got refresh with valid access token." "$OUTPUT" \
+        || pass "Could not refresh with valid access token."


### PR DESCRIPTION
Stop treating a refresh_token as a part of the access_token; instead
generate, store, etc. refresh_tokens the same way as access_tokens.