### PR TITLE
Refreshed token should include user details

### DIFF
--- a/oauth2-server-snap/lib/Network/OAuth2/Server/Snap.hs
+++ b/oauth2-server-snap/lib/Network/OAuth2/Server/Snap.hs
@@ -119,8 +119,8 @@ createAndServeToken
     :: AccessRequest
     -> Handler b (OAuth2 IO b) ()
 createAndServeToken request = do
-    OAuth2 Configuration{..} <- get
-    (access_grant, refresh_grant) <- createGrant oauth2SigningKey request
+    OAuth2 cfg@Configuration{..} <- get
+    (access_grant, refresh_grant) <- liftIO $ createGrant cfg request
     liftIO $ tokenStoreSave oauth2Store access_grant
     liftIO $ tokenStoreSave oauth2Store refresh_grant
     serveToken $ grantResponse access_grant (Just $ grantToken refresh_grant)


### PR DESCRIPTION
Update `createGrant` to take a full `OAuth2Server`, not just a key pair, and use this to decode the previous token and copy details into the new token.

This fixes #25