### PR TITLE
Add a (failing) test for scopeText

### DIFF
--- a/oauth2-server/test/test.hs
+++ b/oauth2-server/test/test.hs
@@ -100,9 +100,11 @@ instance Function Token where
     function = functionMap unToken Token
 
 suite :: Spec
-suite = describe "Lens laws" $
+suite = describe "Lens laws" $ do
     prop "apply for anchorTokenTokenGrant" $ isIso $
         anchorTokenTokenGrant crypto
+
+    prop "apply for scopeText" $ isIso scopeText
 
 main :: IO ()
 main = hspec suite


### PR DESCRIPTION
This test fails, as we do reordering, deduplication and whitespace normalization. Should we ignore this and leave it as an `Iso` or change it so it is less confusing?