### PR TITLE
Refreshed token should use old token scope as default

### DIFF
--- a/oauth2-server/lib/Network/OAuth2/Server.hs
+++ b/oauth2-server/lib/Network/OAuth2/Server.hs
@@ -78,7 +78,7 @@ createGrant Configuration{..} request = do
                 return
                     ( requestClientID
                     , join $ grantUsername <$> previous
-                    , fromMaybe mempty requestScope
+                    , fromMaybe mempty (requestScope <|> (grantScope <$> previous))
                     )
     let expires = addUTCTime 1800 t
         access_token = AnchorToken


### PR DESCRIPTION
This will resolve the outstanding acceptance test failure on oauth2.