### PR TITLE
Orphans

### DIFF
--- a/lib/Network/OAuth2/Server.hs
+++ b/lib/Network/OAuth2/Server.hs
@@ -14,14 +14,23 @@ module Network.OAuth2.Server (
     NoCache(NoCache),
 ) where
 
-import Control.Monad.Error.Class
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Except
-import Data.Aeson
-import Data.ByteString.Conversion
-import Data.Time.Clock
+import Control.Monad.Error.Class ( MonadError(throwError) )
+import Control.Monad.IO.Class ( MonadIO(liftIO) )
+import Control.Monad.Trans.Except ( ExceptT, runExceptT )
+import Data.Aeson ( encode )
+import Data.ByteString.Conversion ( ToByteString(..) )
+import Data.Time.Clock ( UTCTime, addUTCTime, getCurrentTime )
 import Servant.API
+    ( type (:>),
+      Headers,
+      AddHeader(addHeader),
+      ReqBody,
+      Post,
+      Header,
+      JSON,
+      FormUrlEncoded )
 import Servant.Server
+    ( ServantErr(errBody, errHeaders), Server, err400 )
 
 import Network.OAuth2.Server.Configuration as X
 import Network.OAuth2.Server.Types as X

--- a/lib/Network/OAuth2/Server/Configuration.hs
+++ b/lib/Network/OAuth2/Server/Configuration.hs
@@ -13,6 +13,13 @@
 module Network.OAuth2.Server.Configuration where
 
 import Network.OAuth2.Server.Types
+    ( TokenGrant,
+      TokenDetails,
+      Token,
+      Scope,
+      ClientID,
+      AuthHeader,
+      AccessRequest )
 
 -- | The configuration for an OAuth2 server.
 data OAuth2Server m = OAuth2Server

--- a/lib/Network/OAuth2/Server/Types.hs
+++ b/lib/Network/OAuth2/Server/Types.hs
@@ -109,7 +109,7 @@ instance Show ScopeToken where
 instance Read ScopeToken where
     readsPrec n s = [ (x,rest) | (b,rest) <- readsPrec n s, Just x <- [b ^? scopeToken]]
 
--- | A scope is a nonemty set of `ScopeToken`s
+-- | A scope is a non-empty set of `ScopeToken`s
 newtype Scope = Scope { unScope :: Set ScopeToken }
   deriving (Eq, Read, Show, Typeable)
 

--- a/lib/Network/OAuth2/Server/Types.hs
+++ b/lib/Network/OAuth2/Server/Types.hs
@@ -49,31 +49,53 @@ module Network.OAuth2.Server.Types (
   vschar,
 ) where
 
-import Blaze.ByteString.Builder
+import Blaze.ByteString.Builder ( toByteString )
 import Control.Applicative
-import Control.Lens.Fold
-import Control.Lens.Operators hiding ((.=))
-import Control.Lens.Prism
-import Control.Lens.Review
-import Control.Monad
+    ( Applicative((<*), (<*>), pure), (<$>) )
+import Control.Lens.Fold ( (^?) )
+import Control.Lens.Operators ( (^.) )
+import Control.Lens.Prism ( Prism', prism' )
+import Control.Lens.Review ( review, re )
+import Control.Monad ( guard )
 import Data.Aeson
+    ( Value(String),
+      ToJSON(..),
+      FromJSON(..),
+      object,
+      withText,
+      withObject,
+      (.=),
+      (.:?),
+      (.:) )
 import Data.Attoparsec.ByteString
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
+    ( Parser, endOfInput, sepBy1, word8, takeWhile1, parseOnly )
+import Data.ByteString ( ByteString )
+import qualified Data.ByteString as B ( null, intercalate, all )
 import qualified Data.ByteString.Lazy as BSL
-import Data.CaseInsensitive
-import Data.Char
-import Data.Monoid
-import Data.Set (Set)
+    ( toStrict, fromStrict )
+import Data.CaseInsensitive ( mk )
+import Data.Char ( ord )
+import Data.Monoid ( (<>) )
+import Data.Set ( Set )
 import qualified Data.Set as S
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import Data.Time.Clock
-import Data.Typeable
-import Data.Word
-import Servant.API hiding (URI)
+    ( toList, null, fromList, difference )
+import Data.Text ( Text )
+import qualified Data.Text as T ( unpack, all )
+import qualified Data.Text.Encoding as T ( encodeUtf8, decodeUtf8 )
+import Data.Time.Clock ( UTCTime, diffUTCTime )
+import Data.Typeable ( Typeable )
+import Data.Word ( Word8 )
+import Servant.API
+    ( ToText(..),
+      FromText(..),
+      ToFormUrlEncoded(..),
+      OctetStream,
+      MimeUnrender(..),
+      MimeRender(..),
+      FromFormUrlEncoded(..) )
 import URI.ByteString
+    ( URI, strictURIParserOptions, serializeURI, parseURI )
+
 
 vschar :: Word8 -> Bool
 vschar c = c>=0x20 && c<=0x7E


### PR DESCRIPTION
This is a bit of a shot in the dark.  Any feedback welcome.

I have removed the `From-, ToJSON` orphan instances for `URI` with surprisingly little effort.  I'm not sure if I missed anything, but if the only place where they are needed is for the error packages, I think my change is not so bad.  I am happy to introduce a newtype if you prefer that.

I think I also talked to the uri-bytestring people about depending on aeson a while back, but the reasonably said no thanks.  (-:

Note that this branch includes #49.  Let me know if you want me to change that.
