### PR TITLE
Test: refresh tokens

### DIFF
--- a/lib/Network/OAuth2/Server/Store.hs
+++ b/lib/Network/OAuth2/Server/Store.hs
@@ -157,11 +157,11 @@ instance TokenStore (Pool Connection) where
     storeSaveToken pool grant = do
         debugM logName $ "Saving new token: " <> show grant
         res :: [TokenDetails] <- withResource pool $ \conn -> do
-            query conn "INSERT INTO tokens (token_type, expires, user_id, client_id, scope) VALUES (?,?,?,?,?) RETURNING (token_type, token, expires, user_id, client_id, scope)" (grant)
+            query conn "INSERT INTO tokens (token_type, expires, user_id, client_id, scope, token, created) VALUES (?,?,?,?,?,uuid_generate_v4(), NOW()) RETURNING token_type, token, expires, user_id, client_id, scope" grant
         case res of
-            [] -> fail $ "Failed to save new token: " <> show grant
             [tok] -> return tok
-            _       -> fail "Impossible: multiple tokens returned from single insert"
+            []    -> fail $ "Failed to save new token: " <> show grant
+            _     -> fail "Impossible: multiple tokens returned from single insert"
 
     storeLoadToken pool tok = do
         debugM logName $ "Loading token: " <> show tok

--- a/lib/Network/OAuth2/Server/Types.hs
+++ b/lib/Network/OAuth2/Server/Types.hs
@@ -58,6 +58,7 @@ module Network.OAuth2.Server.Types (
   tokenDetails,
   unicodecharnocrlf,
   UserID,
+  userid,
   Username,
   username,
   vschar,
@@ -143,6 +144,9 @@ newtype UserID = UserID
 
 instance ToField UserID where
     toField = toField . unpackUserID
+
+userid :: Prism' ByteString UserID
+userid = prism' (T.encodeUtf8 . unpackUserID) (Just . UserID . T.decodeUtf8)
 
 newtype TokenID = TokenID { unTokenID :: Text }
     deriving (Eq, Show, Ord, ToValue, FromText)
@@ -920,7 +924,7 @@ instance ToRow TokenGrant where
         , ex
         , review username <$> uid
         , review clientID <$> cid
-        , scopeToBs sc
+        , sc
         )
 
 instance FromRow TokenDetails where

--- a/lib/Network/OAuth2/Server/Types.hs
+++ b/lib/Network/OAuth2/Server/Types.hs
@@ -200,7 +200,7 @@ data ClientDetails = ClientDetails
     { clientClientId     :: ClientID
     , clientSecret       :: EncryptedPass
     , clientConfidential :: Bool
-    , clientRedirectURI  :: RedirectURI
+    , clientRedirectURI  :: [RedirectURI]
     , clientName         :: Text
     , clientDescription  :: Text
     , clientAppUrl       :: URI
@@ -939,8 +939,8 @@ instance FromField RedirectURI where
     fromField f bs = do
         x <- fromField f bs
         case x ^? redirectURI of
-            Nothing -> returnError ConversionFailed f ""
-            Just uri -> return uri
+            Nothing -> returnError ConversionFailed f $ "Prism failed to conver URI: " <> show x
+            Just uris -> return uris
 
 instance ToField RedirectURI where
     toField = toField . review redirectURI
@@ -956,7 +956,7 @@ instance FromRow ClientDetails where
     fromRow = ClientDetails <$> field
                             <*> (EncryptedPass <$> field)
                             <*> field
-                            <*> field
+                            <*> (V.toList <$> field)
                             <*> field
                             <*> field
                             <*> fieldWith fromFieldURI

--- a/oauth2-server.cabal
+++ b/oauth2-server.cabal
@@ -146,12 +146,18 @@ test-suite             test-acceptance
   hs-source-dirs:      test
   main-is:             acceptance.hs
   build-depends:       base
+                     , aeson
                      , bytestring
+                     , hoauth2
                      , hspec
                      , http-client
                      , http-types
                      , lens
                      , lens-aeson
+                     , mtl
                      , oauth2-server
+                     , servant
                      , text
+                     , transformers
+                     , transformers-compat
                      , wreq

--- a/schema/postgresql.sql
+++ b/schema/postgresql.sql
@@ -22,7 +22,7 @@ CREATE TABLE clients (
 -- Store codes for use in Authorizatrion Code Grant
 -- https://tools.ietf.org/html/rfc6749#section-4.1
 CREATE TABLE request_codes (
-    code         UUID         NOT NULL DEFAULT uuid_generate_v4(),
+    code         UUID           NOT NULL DEFAULT uuid_generate_v4(),
 
     authorized   BOOLEAN        NOT NULL DEFAULT FALSE,
     expires TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW() + '10 minutes',


### PR DESCRIPTION
This PR contains an acceptance test for refreshing a token; and fixes several bugs discovered while writing the test:

- PostgreSQL `RETURNING` clauses take a list of values to return; if you wrap the list in `(...)` then you get a single record value, not a list of values.

- If a refresh request is received with no scope, we should check and grant the request with the previous scope.

- RedirectURI's PG support was wacky; it's fixed now, but there's still refactoring to do. See the commit messages below.
