### PR TITLE
Cleanup API + fix warnings

### DIFF
--- a/oauth2-server.cabal
+++ b/oauth2-server.cabal
@@ -102,6 +102,7 @@ test-suite             test-tokenstore
                      , configurator
                      , errors
                      , hspec
+                     , hspec-core
                      , lens
                      , mtl
                      , oauth2-server

--- a/test/tokenstore.hs
+++ b/test/tokenstore.hs
@@ -14,7 +14,7 @@ module Main where
 import           Control.Applicative
 import           Control.Lens.Operators
 import           Control.Monad
-import           Control.Monad.Error
+import           Control.Monad.Except
 import           Data.ByteString             (ByteString)
 import qualified Data.ByteString.Char8       as B
 import           Data.Maybe
@@ -26,7 +26,7 @@ import           Database.PostgreSQL.Simple
 import           Network.OAuth2.Server
 import           System.Process
 import           Test.Hspec
-import           Test.Hspec.Core             (SpecM)
+import           Test.Hspec.Core.Spec        (SpecM)
 import           Test.Hspec.QuickCheck
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic


### PR DESCRIPTION
API now consistently uses TokenStore instead of fixed on using
(Pool Postgresql.Connection). Removed thin wrapper around server
handler for UI token revocation and creation. (3 functions to 1)