### PR TITLE
Refactored Client, RedirectURI types + prism fixes

### DIFF
--- a/lib/Network/OAuth2/Server/Types/Client.hs
+++ b/lib/Network/OAuth2/Server/Types/Client.hs
@@ -1,0 +1,139 @@
+--
+-- Copyright © 2013-2015 Anchor Systems, Pty Ltd and Others
+--
+-- The code in this file, and the program it is a part of, is
+-- made available to you by its authors as open source software:
+-- you can redistribute it and/or modify it under the terms of
+-- the 3-clause BSD licence.
+--
+
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Types representing OAuth2 clients
+module Network.OAuth2.Server.Types.Client (
+  ClientDetails(..),
+  ClientState,
+  clientState,
+) where
+
+import           Control.Applicative                  ((<$>), (<*>))
+import           Control.Lens.Fold                    (preview, (^?))
+import           Control.Lens.Operators               ((^.))
+import           Control.Lens.Prism                   (Prism', prism')
+import           Control.Lens.Review                  (re, review)
+import           Control.Monad                        (guard)
+import           Crypto.Scrypt                        (EncryptedPass (..))
+import           Data.Aeson                           (FromJSON (..),
+                                                       ToJSON (..),
+                                                       Value (String),
+                                                       withText)
+import           Data.ByteString                      (ByteString)
+import qualified Data.ByteString                      as B (all, null)
+import           Data.Monoid                          ((<>))
+import           Data.Text                            (Text)
+import qualified Data.Text                            as T (unpack)
+import qualified Data.Text.Encoding                   as T (decodeUtf8,
+                                                            encodeUtf8)
+import           Data.Typeable                        (Typeable)
+import qualified Data.Vector                          as V
+import           Database.PostgreSQL.Simple.FromField
+import           Database.PostgreSQL.Simple.FromRow
+import           Database.PostgreSQL.Simple.ToField
+import           Servant.API                          (FromText (..))
+import           URI.ByteString                       (URI)
+
+import           Network.OAuth2.Server.Types.Auth
+import           Network.OAuth2.Server.Types.Common
+
+--------------------------------------------------------------------------------
+
+-- Types
+
+-- | Opaque value used by the client to maintain state between request and
+-- response. Used to prevent cross-site request forgery as defined:
+-- https://tools.ietf.org/html/rfc6749#section-10.12
+newtype ClientState = ClientState { unClientState :: ByteString }
+    deriving (Eq, Typeable)
+
+data ClientDetails = ClientDetails
+    { clientClientId     :: ClientID
+    , clientSecret       :: EncryptedPass
+    , clientConfidential :: Bool
+    , clientRedirectURI  :: [RedirectURI]
+    , clientName         :: Text
+    , clientDescription  :: Text
+    , clientAppUrl       :: URI
+    }
+  deriving (Eq, Show)
+
+--------------------------------------------------------------------------------
+
+-- ByteString Encoding and Decoding
+
+-- | Client state is an opaque non-empty value defined:
+-- https://tools.ietf.org/html/rfc6749#appendix-A.5
+-- state = 1*VSCHAR
+clientState :: Prism' ByteString ClientState
+clientState = prism' cs2b b2cs
+  where
+    cs2b = unClientState
+    b2cs b = do
+        guard . not $ B.null b
+        guard $ B.all vschar b
+        return (ClientState b)
+
+--------------------------------------------------------------------------------
+
+-- String Encoding and Decoding
+
+instance Show ClientState where
+    show = show . review clientState
+
+instance Read ClientState where
+    readsPrec n s = [ (x,rest) | (t,rest) <- readsPrec n s, Just x <- [t ^? clientState]]
+
+--------------------------------------------------------------------------------
+
+-- Servant Encoding and Decoding
+
+instance FromText ClientState where
+    fromText t = T.encodeUtf8 t ^? clientState
+
+--------------------------------------------------------------------------------
+
+-- Postgres Encoding and Decoding
+
+instance FromField ClientState where
+    fromField f bs = do
+        s <- fromField f bs
+        case preview clientState s of
+            Nothing -> returnError ConversionFailed f "Unable to parse ClientState"
+            Just state -> return state
+
+instance ToField ClientState where
+    toField x = toField $ x ^.re clientState
+
+instance FromRow ClientDetails where
+    fromRow = ClientDetails <$> field
+                            <*> (EncryptedPass <$> field)
+                            <*> field
+                            <*> (V.toList <$> field)
+                            <*> field
+                            <*> field
+                            <*> fieldWith fromFieldURI
+
+--------------------------------------------------------------------------------
+
+-- JSON/Aeson Encoding and Decoding
+
+instance ToJSON ClientState where
+    toJSON c = String . T.decodeUtf8 $ c ^.re clientState
+
+instance FromJSON ClientState where
+    parseJSON = withText "ClientState" $ \t ->
+        case T.encodeUtf8 t ^? clientState of
+            Nothing -> fail $ T.unpack t <> " is not a valid ClientState."
+            Just s -> return s
+
+--------------------------------------------------------------------------------

--- a/lib/Network/OAuth2/Server/Types/Common.hs
+++ b/lib/Network/OAuth2/Server/Types/Common.hs
@@ -7,20 +7,55 @@
 -- the 3-clause BSD licence.
 --
 
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 -- | Common types and encoding for OAuth2 Types
-module Network.OAuth2.Server.Types.Common where
+module Network.OAuth2.Server.Types.Common (
+  -- Syntax Descriptions
+  nqchar,
+  nqschar,
+  unicodecharnocrlf,
+  vschar,
+  -- Redirect URIs
+  addQueryParameters,
+  fromFieldURI,
+  RedirectURI,
+  redirectURI,
+  -- URI Aeson,
+  uriFromJSON,
+  uriToJSON,
+  -- HTTP Headers
+  ToHTTPHeaders(..),
+) where
 
-import           Blaze.ByteString.Builder  (toByteString)
-import           Data.Aeson                (ToJSON (..), Value, withText)
-import qualified Data.Aeson.Types          as Aeson (Parser)
-import           Data.Char                 (ord)
-import qualified Data.Text.Encoding        as T (decodeUtf8, encodeUtf8)
-import           Data.Word                 (Word8)
-import           Network.HTTP.Types.Header as HTTP
-import           URI.ByteString            (URI, parseURI, serializeURI,
-                                            strictURIParserOptions)
+import           Blaze.ByteString.Builder             (toByteString)
+import           Control.Lens.Fold                    (preview, (^?))
+import           Control.Lens.Operators               ((%~), (&), (^.))
+import           Control.Lens.Prism                   (Prism', prism')
+import           Control.Lens.Review                  (review)
+import           Data.Aeson                           (ToJSON (..), Value,
+                                                       withText)
+import qualified Data.Aeson.Types                     as Aeson (Parser)
+import           Data.ByteString                      (ByteString)
+import           Data.Char                            (ord)
+import           Data.Monoid                          ((<>))
+import qualified Data.Text.Encoding                   as T (decodeUtf8,
+                                                            encodeUtf8)
+import           Data.Typeable                        (Typeable)
+import           Data.Word                            (Word8)
+import           Database.PostgreSQL.Simple.FromField
+import           Database.PostgreSQL.Simple.ToField
+import           Network.HTTP.Types.Header            as HTTP
+import           Servant.API                          (FromText (..),
+                                                       ToText (..))
+import           URI.ByteString                       (URI, parseURI,
+                                                       queryPairsL,
+                                                       serializeURI,
+                                                       strictURIParserOptions,
+                                                       uriFragmentL,
+                                                       uriQueryL)
 
 --------------------------------------------------------------------------------
 
@@ -61,6 +96,62 @@ unicodecharnocrlf (ord -> c) = or
     , c>=0xE000  && c<=0xFFFD
     , c>=0x10000 && c<=0x10FFFF
     ]
+
+--------------------------------------------------------------------------------
+
+-- Commonly used types
+
+-- | Redirect URIs as used in the OAuth2 RFC.
+newtype RedirectURI = RedirectURI { unRedirectURI :: URI }
+  deriving (Eq, Show, Typeable)
+
+-- | Helper function to safely add query parameters without having to use the
+-- exposed prism to convert to and from Bytestrings and RedirectURIs
+addQueryParameters :: RedirectURI -> [(ByteString, ByteString)] -> RedirectURI
+addQueryParameters (RedirectURI uri) params = RedirectURI $ uri & uriQueryL . queryPairsL %~ (<> params)
+
+-- | Redirect URIs must be absolute and have no fragment as defined:
+-- https://tools.ietf.org/html/rfc6749#section-3.1.2
+-- https://tools.ietf.org/html/rfc3986#section-4.3
+redirectURI :: Prism' ByteString RedirectURI
+redirectURI = prism' fromRedirect toRedirect
+  where
+    fromRedirect :: RedirectURI -> ByteString
+    fromRedirect = toByteString . serializeURI . unRedirectURI
+
+    toRedirect :: ByteString -> Maybe RedirectURI
+    toRedirect bs = case parseURI strictURIParserOptions bs of
+        Left _ -> Nothing
+        Right uri -> case uri ^. uriFragmentL of
+            Just _ -> Nothing
+            Nothing -> Just $ RedirectURI uri
+
+-- Servant instances for RedirectURI
+
+instance FromText RedirectURI where
+    fromText = preview redirectURI . T.encodeUtf8
+
+instance ToText RedirectURI where
+    toText = T.decodeUtf8 . review redirectURI
+
+-- Postgres instances for RedirectURI
+
+instance FromField RedirectURI where
+    fromField f bs = do
+        x <- fromField f bs
+        case x ^? redirectURI of
+            Nothing -> returnError ConversionFailed f $ "Prism failed to conver URI: " <> show x
+            Just uris -> return uris
+
+instance ToField RedirectURI where
+    toField = toField . review redirectURI
+
+fromFieldURI :: FieldParser URI
+fromFieldURI f bs = do
+    x <- fromField f bs
+    case parseURI strictURIParserOptions x of
+        Left e -> returnError ConversionFailed f (show e)
+        Right uri -> return uri
 
 --------------------------------------------------------------------------------
 

--- a/oauth2-server.cabal
+++ b/oauth2-server.cabal
@@ -41,6 +41,7 @@ Library
                      , Network.OAuth2.Server.Store.PostgreSQL
                      , Network.OAuth2.Server.Types
                      , Network.OAuth2.Server.Types.Auth
+                     , Network.OAuth2.Server.Types.Client
                      , Network.OAuth2.Server.Types.Common
                      , Network.OAuth2.Server.Types.Error
                      , Network.OAuth2.Server.Types.Scope


### PR DESCRIPTION
Client state must be nonempty, it's prism allowed it to be.
ClientState and ClientDetails are now in their own file along with their
instances.
RedirectURI and its instances have been moved to Types/Common.hs
Added missing documentation and references to RFC for said types.